### PR TITLE
Incorrect index while adding the same file again

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -29,7 +29,7 @@ impl Index {
             if blob.len() != 2 {
                 return Err(TgitError::InvalidIndex);
             }
-            index.update(blob[1], blob[0]);
+            index.update(blob[0], blob[1]);
         }
         Ok(index)
     }


### PR DESCRIPTION
The index file stores in the format 
Filename Hash

On reading the line from the file, the splits contain the path at the 0th index and hash at the 1st index. 
When readding the same file, the values are stored in reverse way. i.e. "hash path"